### PR TITLE
Don't hardcode to conversejs.org server and set `type` on outgoing messages

### DIFF
--- a/src/ChatClient.js
+++ b/src/ChatClient.js
@@ -9,7 +9,7 @@ export default class ChatClient {
 
   create ({ username, password }) {
     const client = XMPP.createClient({
-      jid: username.indexOf('@conversejs.org') > 0 ? username : `${username}@conversejs.org`,
+      jid: username,
       password,
       transports: {
         websocket: 'wss://conversejs.org/xmpp-websocket',

--- a/src/components/ChatApp/ChatApp.js
+++ b/src/components/ChatApp/ChatApp.js
@@ -129,9 +129,6 @@ class ChatApp extends React.Component {
   }
 
   onNewChat (receiver) {
-    if (receiver.indexOf('@conversejs.org') < 0) {
-      receiver += '@conversejs.org'
-    }
     this.setState({ receiver, section: 'chat' })
   }
 

--- a/src/components/ChatApp/ChatApp.js
+++ b/src/components/ChatApp/ChatApp.js
@@ -63,7 +63,7 @@ class ChatApp extends React.Component {
     const updatedMessages = { ...messages }
     updatedMessages[receiver] = messages[receiver] || []
     updatedMessages[receiver].push({ from: 'Me', to: receiver, body })
-    this.chatClient.send({ to: receiver, body })
+    this.chatClient.send({ to: receiver, type: 'chat', body })
     this.setState({ messages: updatedMessages }, this.scrollChat.bind(this))
     localStorage.setItem('messages', JSON.stringify(updatedMessages))
   }


### PR DESCRIPTION
Hi Ariel

I've been reviewing your chat app as part of the Chat Frontend Engineer role.

Your code looks well-written, clean and tidy, well done!

As I was playing around, I noticed that I couldn't write messages to people on other servers. XMPP is a protocol that allows federation, like email. So you can write a message from `user@conversejs.org` to `user@example.org` and vice versa.

By automatically appending `@conversejs.org` to usernames, you prevented the user from writing to users on other servers. I understand you wanted to make it easier for the user, by requiring just a username without the server part. There are other things one could potentially do to make it more user-friendly.

Additionally, I noticed that your outgoing messages don't have the `chat` type. Generally 1 on 1 chat messages should have the `chat` type although some XMPP clients will accept messages without it.

All the best
JC

